### PR TITLE
Fix build under MinGW (Win32)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ include_directories(${PROJECT_SOURCE_DIR}/include/)
 add_library(${PROJECT_NAME} SHARED ${boost_json_archive_SRC})
 
 target_link_libraries(${PROJECT_NAME}
+	Boost::serialization
 	Boost::json
 )
 

--- a/cmake/Config.cmake
+++ b/cmake/Config.cmake
@@ -27,7 +27,7 @@ set(INSTALL_LIB_DIR      ${BASE_INSTALL_DIR}/lib                                
 set(INSTALL_BIN_DIR      ${BASE_INSTALL_DIR}/bin                                     CACHE PATH "Installation directory for executables")
 set(INSTALL_INCLUDE_DIR  ${BASE_INSTALL_DIR}/include                                 CACHE PATH "Installation directory for header files")
 if(WIN32 AND NOT CYGWIN)
-  set(DEF_INSTALL_CMAKE_DIR CMake)
+  set(DEF_INSTALL_CMAKE_DIR ${BASE_INSTALL_DIR}/CMake/)
 else()
   set(DEF_INSTALL_CMAKE_DIR ${INSTALL_LIB_DIR}/CMake/)
 endif()

--- a/include/boost/JsonContext.hpp
+++ b/include/boost/JsonContext.hpp
@@ -27,17 +27,17 @@ const std::string TrackingType("tracking");
 
 #ifdef __GNUG__
 
-std::string demangle(const char *name);
+std::string BOOST_SYMBOL_EXPORT demangle(const char *name);
 
 #else
 // does nothing if not g++
-std::string demangle(const char *name);
+std::string BOOST_SYMBOL_EXPORT demangle(const char *name);
 #endif
 
 /**
  * @brief JsonContext Class. Helper for boost::serialization::json.
  */
-class JsonContext {
+class BOOST_SYMBOL_EXPORT JsonContext {
 
 public:
   typedef std::shared_ptr<boost::json::value> json_value;

--- a/include/boost/archive/json_iarchive.hpp
+++ b/include/boost/archive/json_iarchive.hpp
@@ -17,7 +17,7 @@
 namespace boost {
 namespace archive {
 
-class json_iarchive : public detail::common_iarchive<json_iarchive> {
+class BOOST_SYMBOL_EXPORT json_iarchive : public detail::common_iarchive<json_iarchive> {
 public:
   explicit json_iarchive(std::istream &is, unsigned int = 0);
 

--- a/include/boost/archive/json_oarchive.hpp
+++ b/include/boost/archive/json_oarchive.hpp
@@ -17,7 +17,7 @@
 namespace boost {
 namespace archive {
 
-class json_oarchive : public detail::common_oarchive<json_oarchive> {
+class BOOST_SYMBOL_EXPORT json_oarchive : public detail::common_oarchive<json_oarchive> {
 public:
   explicit json_oarchive(std::ostream &os, unsigned int = 0, const bool prettify = false);
 

--- a/src/json_iarchive.cpp
+++ b/src/json_iarchive.cpp
@@ -81,7 +81,7 @@ void json_iarchive::load_override(class_id_optional_type &t) {
     return;
   }
 
-  t = class_id_optional_type(class_id_type(static_cast<uint64_t>(data.as_int64())));
+  t = class_id_optional_type(class_id_type(static_cast<size_t>(data.as_int64())));
 }
 
 void json_iarchive::load_override(class_id_reference_type &t) {
@@ -92,7 +92,7 @@ void json_iarchive::load_override(class_id_reference_type &t) {
   if (!data.is_number()) {
     return;
   }
-  t = class_id_reference_type(class_id_type(static_cast<uint64_t>(data.as_int64())));
+  t = class_id_reference_type(class_id_type(static_cast<size_t>(data.as_int64())));
 }
 
 void json_iarchive::load_override(tracking_type &t) {


### PR DESCRIPTION
Please consider the following commits, which fix **building with MinGW** (aka "GCC for **Windows**"):

- cmake failed with "_file RELATIVE_PATH must be passed a full path to the directory_", due to an obsolete "_if(WIN32_" section in **Config.cmake**;
- cmake did not link correctly due to a missing "Boost::serialization" statement in **CMakeLists.txt** (may be auto-deduced under Linux);
- with MinGW 8.1.0, some "_static_cast<uint64_64>_" must be replaced with "_static_cast<size_t>_" in **json_iarchive.cpp** (otherwise the compiler finds them ambiguous);
- when producing a DLL with MinGW, symbols do not get exported at all. Export them with the BOOST_SYMBOL_EXPORT macro in **json_iarchive.hpp**, **json_oarchive.cpp**, **JsonContext.hpp**.